### PR TITLE
Fix overflow on small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,7 +98,6 @@ h2 {
   flex-wrap: wrap;
 }
 
-/* media query screen size */
 @media (max-width: 625px) {
   .buttons {
     flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -85,7 +85,6 @@ h2 {
 
 .infoText {
   width: 100%;
-  height: 28px;
   justify-content: center;
   display: flex;
   color: #fff;
@@ -96,6 +95,14 @@ h2 {
 .buttons {
   margin: 20px;
   display: flex;
+  flex-wrap: wrap;
+}
+
+/* media query screen size */
+@media (max-width: 625px) {
+  .buttons {
+    flex-direction: column;
+  }
 }
 
 .buttons button {
@@ -107,7 +114,7 @@ h2 {
   font-size: 18px;
   background-color: #9198e5;
   transition: 200ms;
-  margin: 0 10px;
+  margin: 10px;
   font-weight: bolder;
   width: 160px;
   box-shadow: 0px 0px 30px 0px rgba(0,0,0,0.10);


### PR DESCRIPTION
<img width="334" alt="Screenshot 2022-10-16 at 12 51 24" src="https://user-images.githubusercontent.com/3826262/196031239-e63a7526-a07e-44dd-b374-f65818cfafd4.png">

Fixes the overflowing buttons on small screen as mentioned in https://github.com/3DJakob/react-tinder-card-demo/issues/41